### PR TITLE
Added support for class expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "files": [
     "lib",
-    "src"
+    "src",
+    ".babelrc"
   ],
   "dependencies": {
     "babel-types": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "clean": "rimraf lib",
     "build": "babel src -d lib",
+    "install": "npm run build",
     "lint": "prettier --list-different \"src/**/*.js\" \"test/test.js\" && eslint \"src/**/*.js\" \"test/test.js\"",
     "lint:fix": "prettier --write \"src/**/*.js\" \"test/test.js\" && eslint --fix \"src/**/*.js\" \"test/test.js\"",
     "prerelease": "npm run clean && npm run build",

--- a/src/index.js
+++ b/src/index.js
@@ -12,77 +12,91 @@ function isFragment(path) {
     );
 }
 
-export default function ({ types: t }) {
-  const checkElementAndAddAttribute = (path, name, property) => {
-    // if its not react fragment
-    if (!isFragment(path)) {
-      path.node.attributes.unshift(
-        t.jSXAttribute(
-          t.jSXIdentifier(property),
-          t.stringLiteral(name),
-          // t.JSXExpressionContainer(t.Identifier('this.constructor.name')),
-        ),
-      );
+const ClassDeclaration = (t, property) => {
+  return (path2) => {
+    if (!isReactComponent(path2)) {
+      return;
     }
+    const name = getEntryIdentifier(path2);
 
-    path.stop()
+    if (name) {
+      path2.traverse({
+        ClassMethod: path3 => {
+          if (path3.node.key.name === 'render') {
+            path3.traverse({
+              JSXOpeningElement(path4) {
+                checkElementAndAddAttribute(t, path4, name, property);
+              },
+            })
+          }
+        },
+      })
+    }
+  };
+};
+
+const ClassExpression = ClassDeclaration; 
+
+const ArrowFunctionExpression = (t, property) => {
+  return (path2) => {
+    if (!isReactComponent(path2)) {
+      return;
+    }
+    const name = getEntryIdentifier(path2);
+    path2.traverse({
+      JSXOpeningElement(path3) {
+        checkElementAndAddAttribute(t, path3, name, property);
+      },
+    })
+  };
+};
+
+const FunctionDeclaration = (t, property) => {
+  return (path2) => {
+    if (!isReactComponent(path2)) {
+      return;
+    }
+    const name = getEntryIdentifier(path2);
+    if (name) {
+      path2.traverse({
+        JSXOpeningElement(path3) {
+          checkElementAndAddAttribute(t, path3, name, property);
+        },
+      })
+    }
+  };
+};
+
+const checkElementAndAddAttribute = (t, path, name, property) => {
+  // if its not react fragment
+  if (!isFragment(path)) {
+    path.node.attributes.unshift(
+      t.jSXAttribute(
+        t.jSXIdentifier(property),
+        t.stringLiteral(name)
+      )
+    );
   }
+
+  path.stop();
+}
+
+export default function ({ types: t }) {
   return {
     manipulateOptions: (opts, parserOptions) => {
-      parserOptions.plugins.push('jsx')
+      parserOptions.plugins.push('jsx');
     },
     visitor: {
       Program(path, state) {
-        const property = state.opts.property || 'data-name'
+        const property = state.opts.property || 'data-name';
 
         path.traverse({
-          ClassDeclaration: path2 => {
-            if (!isReactComponent(path2)) {
-              return
-            }
-            const name = getEntryIdentifier(path2)
-
-            if (name) {
-              path2.traverse({
-                ClassMethod: path3 => {
-                  if (path3.node.key.name === 'render') {
-                    path3.traverse({
-                      JSXOpeningElement(path4) {
-                        checkElementAndAddAttribute(path4, name, property);
-                      },
-                    })
-                  }
-                },
-              })
-            }
-          },
-          ArrowFunctionExpression: path2 => {
-            if (!isReactComponent(path2)) {
-              return
-            }
-            const name = getEntryIdentifier(path2);
-            path2.traverse({
-              JSXOpeningElement(path3) {
-                checkElementAndAddAttribute(path3, name, property);
-              },
-            })
-
-          },
-          FunctionDeclaration: path2 => {
-            if (!isReactComponent(path2)) {
-              return
-            }
-            const name = getEntryIdentifier(path2)
-            if (name) {
-              path2.traverse({
-                JSXOpeningElement(path3) {
-                  checkElementAndAddAttribute(path3, name, property);
-                },
-              })
-            }
-          },
-        })
-      },
-    },
+          ClassDeclaration: ClassDeclaration(t, property),
+          ClassExpression: ClassExpression(t, property),
+          ArrowFunctionExpression: ArrowFunctionExpression(t, property),
+          FunctionDeclaration: FunctionDeclaration(t, property)
+        });
+      }
+    }
   }
-}
+};

--- a/test/fixtures/statefull-multirender/actual.js
+++ b/test/fixtures/statefull-multirender/actual.js
@@ -1,6 +1,18 @@
 import React, { Component } from 'react';
 
-export default class Example extends Component {
+export default class Example1 extends Component {
+  renderHeader() {
+    return <hr />;
+  }
+  render() {
+    if (this.props.loading) {
+      return <p />;
+    }
+    return <div />;
+  }
+}
+
+let Example2 = class Example2 extends Component {
   renderHeader() {
     return <hr />;
   }

--- a/test/fixtures/statefull-multirender/expected.js
+++ b/test/fixtures/statefull-multirender/expected.js
@@ -1,13 +1,25 @@
 import React, { Component } from 'react';
 
-export default class Example extends Component {
+export default class Example1 extends Component {
   renderHeader() {
     return <hr />;
   }
   render() {
     if (this.props.loading) {
-      return <p data-name="Example" />;
+      return <p data-name="Example1" />;
     }
-    return <div data-name="Example" />;
+    return <div data-name="Example1" />;
   }
 }
+
+let Example2 = class Example2 extends Component {
+  renderHeader() {
+    return <hr />;
+  }
+  render() {
+    if (this.props.loading) {
+      return <p data-name="Example2" />;
+    }
+    return <div data-name="Example2" />;
+  }
+};

--- a/test/fixtures/statefull-pure/actual.js
+++ b/test/fixtures/statefull-pure/actual.js
@@ -1,6 +1,12 @@
 import React, { PureComponent } from 'react';
 
-export default class Example extends PureComponent {
+export default class Example1 extends PureComponent {
+  render() {
+    return <div someOtherAttribute/>;
+  }
+}
+
+let Example2 = class Example2 extends PureComponent {
   render() {
     return <div someOtherAttribute/>;
   }

--- a/test/fixtures/statefull-pure/expected.js
+++ b/test/fixtures/statefull-pure/expected.js
@@ -1,7 +1,13 @@
 import React, { PureComponent } from 'react';
 
-export default class Example extends PureComponent {
+export default class Example1 extends PureComponent {
   render() {
-    return <div data-name="Example" someOtherAttribute />;
+    return <div data-name="Example1" someOtherAttribute />;
   }
 }
+
+let Example2 = class Example2 extends PureComponent {
+  render() {
+    return <div data-name="Example2" someOtherAttribute />;
+  }
+};

--- a/test/fixtures/statefull/actual.js
+++ b/test/fixtures/statefull/actual.js
@@ -1,6 +1,12 @@
 import React, { Component } from 'react';
 
-export default class Example extends Component {
+export default class Example1 extends Component {
+  render() {
+    return <div someOtherAttribute/>;
+  }
+}
+
+let Example2 = class Example2 extends Component {
   render() {
     return <div someOtherAttribute/>;
   }

--- a/test/fixtures/statefull/expected.js
+++ b/test/fixtures/statefull/expected.js
@@ -1,7 +1,13 @@
 import React, { Component } from 'react';
 
-export default class Example extends Component {
+export default class Example1 extends Component {
   render() {
-    return <div data-name="Example" someOtherAttribute />;
+    return <div data-name="Example1" someOtherAttribute />;
   }
 }
+
+let Example2 = class Example2 extends Component {
+  render() {
+    return <div data-name="Example2" someOtherAttribute />;
+  }
+};


### PR DESCRIPTION
I needed to add this because TypeScript compiles classes to class expressions and this Babel plugin currently didn't handle those. This change is to support Cypress testing in environments where class/component names get mangled and therefore breaks our `@withTestId` decorator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zaiusinc/babel-plugin-component-name-as-jsx-prop-/1)
<!-- Reviewable:end -->
